### PR TITLE
include Utilities so that make works

### DIFF
--- a/Examples/src/Rational/Makefile
+++ b/Examples/src/Rational/Makefile
@@ -19,6 +19,8 @@ include $(MAKEFILEH_DIR)/Makefile.inc
 #
 # You may have an include file also in the current directory
 #
+# update CPPFLAGS to find hashCombine
+CPPFLAGS+=-I${PACS_ROOT}/src/Utilities
 -include Makefile.inc
 
 #
@@ -36,8 +38,6 @@ HEADERS=$(wildcard *.hpp)
 #
 exe_sources=$(filter main%.cpp,$(SRCS))
 EXEC=$(exe_sources:.cpp=)
-# update CPPFLAGS to find hashCombine
-CPPFLAGS+=-I${PACS_ROOT}/src/Utilities
 
 #========================== ORA LA DEFINIZIONE DEGLI OBIETTIVI
 .phony= all clean distclean doc

--- a/Examples/src/Rational/Makefile
+++ b/Examples/src/Rational/Makefile
@@ -36,6 +36,8 @@ HEADERS=$(wildcard *.hpp)
 #
 exe_sources=$(filter main%.cpp,$(SRCS))
 EXEC=$(exe_sources:.cpp=)
+# update CPPFLAGS to find hashCombine
+CPPFLAGS+=-I${PACS_ROOT}/src/Utilities
 
 #========================== ORA LA DEFINIZIONE DEGLI OBIETTIVI
 .phony= all clean distclean doc


### PR DESCRIPTION
Else the following error happens:
g++ -g -std=c++20 -Wall -Wextra -Wsuggest-override -Wnon-virtual-dtor -I. -I./include -I/home/alfredo/Documents/Polimi/PACS/pacs-examples/Examples/include  -I/u/sw/toolchains/gcc-glibc/11.2.0/pkgs/eigen/3.3.9/include/eigen3      -c -o main_rational.o main_rational.cpp
In file included from main_rational.cpp:1:
rational.hpp:6:10: fatal error: hashCombine.hpp: No such file or directory
    6 | #include "hashCombine.hpp" // for the hash function
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [<builtin>: main_rational.o] Error 1