### PR TITLE
Ignore generated clangd compilation databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,10 @@ Examples/src/*/doc/*
 # configuration files
 Examples/Makefile.inc
 
+# generated clangd compilation commands and index
+compile_commands.json
+**/.cache/clangd/
+
 # backup files
 *~
 


### PR DESCRIPTION
Tools like [bear](https://github.com/rizsotto/Bear) can automatically generate a compilation database for clang to know how a translation unit should be compiled, allowing for example clangd with neovim to provide accurate auto-completions, function signatures etc. Since they are generally automatically generated, it would make sense to keep them out of vc by default. I don't know if others are using this on the course, but it would make untracked files cleaner in my environment.